### PR TITLE
Add support for optional 'enabled' boolean column in tenant configuration

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -199,6 +199,7 @@ Tenants can optionally include a `desired_logs` field in their DynamoDB configur
   "log_distribution_role_arn": "arn:aws:iam::123456789012:role/LogDistributionRole",
   "log_group_name": "/aws/logs/acme-corp",
   "target_region": "us-east-1",
+  "enabled": true,
   "desired_logs": ["payment-service", "user-service", "api-gateway"]
 }
 ```
@@ -207,6 +208,11 @@ Tenants can optionally include a `desired_logs` field in their DynamoDB configur
 
 The filtering logic operates as follows:
 
+**Tenant-Level Enablement:**
+* **`enabled: true` or field missing**: Tenant logs are processed normally (backward compatibility)
+* **`enabled: false`**: All logs for this tenant are skipped, regardless of other configuration
+
+**Application-Level Filtering (when tenant is enabled):**
 * **No `desired_logs` field**: All application logs are processed (full backward compatibility)
 * **`desired_logs` present**: Only applications listed in the array are processed
 * **Case-insensitive matching**: Application names are matched without regard to case for robustness


### PR DESCRIPTION
## Summary
- Adds support for an optional `enabled` boolean column in the DynamoDB tenant configuration table
- Allows administrators to enable/disable log processing for specific tenants without deleting their configuration
- Maintains full backward compatibility (defaults to `enabled=true` if field is missing)

## Changes Made

### Code Changes (`container/log_processor.py`)
- Enhanced `get_tenant_configuration()` to extract and log the `enabled` field with backward compatibility
- Added new `should_process_tenant()` function to check tenant enabled status
- Updated `process_sqs_record()` to check tenant enablement before application filtering
- Added appropriate logging when tenants are skipped due to being disabled

### Documentation Updates
- **docs/README.md**: Added comprehensive DynamoDB tenant configuration schema documentation
- **CLAUDE.md**: Added detailed tenant configuration section with operational commands
- **DESIGN.md**: Updated configuration schema examples and filtering behavior documentation

## Features
- **Early Filtering**: Disabled tenants are filtered out before expensive S3 operations
- **Operational Control**: Quick disable/enable without configuration deletion
- **Clear Logging**: Explicit messages when tenants are disabled
- **Backward Compatibility**: Existing tenants continue working unchanged

## Usage
```bash
# Disable a tenant
aws dynamodb update-item \
  --table-name TENANT_CONFIG_TABLE \
  --key '{"tenant_id":{"S":"TENANT_ID"}}' \
  --update-expression "SET enabled = :val" \
  --expression-attribute-values '{":val":{"BOOL":false}}'

# Enable a tenant
aws dynamodb update-item \
  --table-name TENANT_CONFIG_TABLE \
  --key '{"tenant_id":{"S":"TENANT_ID"}}' \
  --update-expression "SET enabled = :val" \
  --expression-attribute-values '{":val":{"BOOL":true}}'
```

🤖 Generated with [Claude Code](https://claude.ai/code)