### PR TITLE
Update rpms-signature-scan task image to new SHA

### DIFF
--- a/.tekton/rosa-log-router-api-pull-request.yaml
+++ b/.tekton/rosa-log-router-api-pull-request.yaml
@@ -571,7 +571,7 @@ spec:
         - name: name
           value: rpms-signature-scan
         - name: bundle
-          value: quay.io/konflux-ci/konflux-vanguard/task-rpms-signature-scan:0.2@sha256:232bd319a7b85720c645783dcada0b633398424700de3f75549eaf524144007e
+          value: quay.io/konflux-ci/konflux-vanguard/task-rpms-signature-scan:0.2@sha256:49ff6d117c3e9dc3966d1244e118e168b3501742ec14c3a4161a276ff48d04d5
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/rosa-log-router-api-push.yaml
+++ b/.tekton/rosa-log-router-api-push.yaml
@@ -568,7 +568,7 @@ spec:
         - name: name
           value: rpms-signature-scan
         - name: bundle
-          value: quay.io/konflux-ci/konflux-vanguard/task-rpms-signature-scan:0.2@sha256:232bd319a7b85720c645783dcada0b633398424700de3f75549eaf524144007e
+          value: quay.io/konflux-ci/konflux-vanguard/task-rpms-signature-scan:0.2@sha256:49ff6d117c3e9dc3966d1244e118e168b3501742ec14c3a4161a276ff48d04d5
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/rosa-log-router-authorizer-pull-request.yaml
+++ b/.tekton/rosa-log-router-authorizer-pull-request.yaml
@@ -572,7 +572,7 @@ spec:
         - name: name
           value: rpms-signature-scan
         - name: bundle
-          value: quay.io/konflux-ci/konflux-vanguard/task-rpms-signature-scan:0.2@sha256:232bd319a7b85720c645783dcada0b633398424700de3f75549eaf524144007e
+          value: quay.io/konflux-ci/konflux-vanguard/task-rpms-signature-scan:0.2@sha256:49ff6d117c3e9dc3966d1244e118e168b3501742ec14c3a4161a276ff48d04d5
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/rosa-log-router-authorizer-push.yaml
+++ b/.tekton/rosa-log-router-authorizer-push.yaml
@@ -569,7 +569,7 @@ spec:
         - name: name
           value: rpms-signature-scan
         - name: bundle
-          value: quay.io/konflux-ci/konflux-vanguard/task-rpms-signature-scan:0.2@sha256:232bd319a7b85720c645783dcada0b633398424700de3f75549eaf524144007e
+          value: quay.io/konflux-ci/konflux-vanguard/task-rpms-signature-scan:0.2@sha256:49ff6d117c3e9dc3966d1244e118e168b3501742ec14c3a4161a276ff48d04d5
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/rosa-log-router-processor-pull-request.yaml
+++ b/.tekton/rosa-log-router-processor-pull-request.yaml
@@ -572,7 +572,7 @@ spec:
         - name: name
           value: rpms-signature-scan
         - name: bundle
-          value: quay.io/konflux-ci/konflux-vanguard/task-rpms-signature-scan:0.2@sha256:232bd319a7b85720c645783dcada0b633398424700de3f75549eaf524144007e
+          value: quay.io/konflux-ci/konflux-vanguard/task-rpms-signature-scan:0.2@sha256:49ff6d117c3e9dc3966d1244e118e168b3501742ec14c3a4161a276ff48d04d5
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/rosa-log-router-processor-push.yaml
+++ b/.tekton/rosa-log-router-processor-push.yaml
@@ -569,7 +569,7 @@ spec:
         - name: name
           value: rpms-signature-scan
         - name: bundle
-          value: quay.io/konflux-ci/konflux-vanguard/task-rpms-signature-scan:0.2@sha256:232bd319a7b85720c645783dcada0b633398424700de3f75549eaf524144007e
+          value: quay.io/konflux-ci/konflux-vanguard/task-rpms-signature-scan:0.2@sha256:49ff6d117c3e9dc3966d1244e118e168b3501742ec14c3a4161a276ff48d04d5
         - name: kind
           value: task
         resolver: bundles


### PR DESCRIPTION
## Summary
- Updated rpms-signature-scan task image reference across all Tekton pipeline configurations
- Changed SHA hash from `232bd319a7b85720c645783dcada0b633398424700de3f75549eaf524144007e` to `49ff6d117c3e9dc3966d1244e118e168b3501742ec14c3a4161a276ff48d04d5`
- Updated image location: `quay.io/konflux-ci/konflux-vanguard/task-rpms-signature-scan:0.2`

## Files Changed
- `.tekton/rosa-log-router-api-pull-request.yaml`
- `.tekton/rosa-log-router-api-push.yaml`
- `.tekton/rosa-log-router-authorizer-pull-request.yaml`
- `.tekton/rosa-log-router-authorizer-push.yaml`
- `.tekton/rosa-log-router-processor-pull-request.yaml`
- `.tekton/rosa-log-router-processor-push.yaml`

## Test plan
- [ ] Verify pipeline configurations are valid
- [ ] Test that rpms-signature-scan task runs successfully with new image
- [ ] Ensure all affected pipelines continue to work as expected

🤖 Generated with [Claude Code](https://claude.ai/code)