### PR TITLE
fix: ensure exact log group/stream name matching in CloudWatch delivery

### DIFF
--- a/container/log_processor.py
+++ b/container/log_processor.py
@@ -888,20 +888,23 @@ def ensure_log_group_and_stream_exist(logs_client, log_group: str, log_stream: s
     """
     try:
         # Check if log group exists, create if not
-        try:
-            logs_client.describe_log_groups(logGroupNamePrefix=log_group, limit=1)
-        except logs_client.exceptions.ResourceNotFoundException:
+        groups = logs_client.describe_log_groups(logGroupNamePrefix=log_group)
+        for group in groups['logGroups']:
+            if group['logGroupName'] == log_group:
+                break
+        else:
             logger.info(f"Creating log group: {log_group}")
             logs_client.create_log_group(logGroupName=log_group)
 
         # Check if log stream exists, create if not
-        try:
-            logs_client.describe_log_streams(
-                logGroupName=log_group,
-                logStreamNamePrefix=log_stream,
-                limit=1
-            )
-        except logs_client.exceptions.ResourceNotFoundException:
+        streams = logs_client.describe_log_streams(
+            logGroupName=log_group,
+            logStreamNamePrefix=log_stream
+        )
+        for stream in streams['logStreams']:
+            if stream['logStreamName'] == log_stream:
+                break
+        else:
             logger.info(f"Creating log stream: {log_stream} in group: {log_group}")
             logs_client.create_log_stream(
                 logGroupName=log_group,


### PR DESCRIPTION
The ensure_log_group_and_stream_exist function was incorrectly using prefix-based API responses to determine if resources existed, causing it to skip creation when other similarly-named resources existed. This resulted in "log stream does not exist" errors during put_log_events calls.

Changed logic to:
- Retrieve actual describe_log_groups/describe_log_streams responses
- Iterate through results to find exact name matches
- Only create resources when exact matches are not found
- Use Python for...else construct for clean conditional creation
- The Exception being watched for didn't actually exist

Fixes ResourceNotFoundException errors in Lambda CloudWatch log delivery.

- Commit message assisted by Cursor