### PR TITLE
Add Terraform provider and backend configuration for Terramate

### DIFF
--- a/terraform/terramate/int/config.tf
+++ b/terraform/terramate/int/config.tf
@@ -1,7 +1,13 @@
 // TERRAMATE: GENERATED AUTOMATICALLY DO NOT EDIT
 
+variable "access_key" {
+}
+variable "secret_key" {
+}
+variable "region" {
+}
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.8.5"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
@@ -12,9 +18,13 @@ terraform {
       version = "~> 3.1"
     }
   }
+  backend "s3" {
+  }
 }
 provider "aws" {
-  region = var.aws_region
+  access_key = var.access_key
+  region     = var.region
+  secret_key = var.secret_key
 }
 provider "aws" {
   alias  = "us-east-1"

--- a/terraform/terramate/int/stack.tm.hcl
+++ b/terraform/terramate/int/stack.tm.hcl
@@ -43,8 +43,13 @@ generate_hcl "main.tf" {
 
 generate_hcl "config.tf" {
   content {
+
+    variable "access_key" {}
+    variable "secret_key" {}
+    variable "region" {}
+
     terraform {
-      required_version = ">= 1.0"
+      required_version = ">= 1.8.5"
       required_providers {
         aws = {
           source  = "hashicorp/aws"
@@ -55,10 +60,13 @@ generate_hcl "config.tf" {
           version = "~> 3.1"
         }
       }
+      backend "s3" {}
     }
 
     provider "aws" {
-      region = var.aws_region
+      access_key = var.access_key
+      secret_key = var.secret_key
+      region     = var.region
     }
 
     tm_dynamic "provider" {


### PR DESCRIPTION
## Summary
- Add Terraform provider and backend configuration for Terramate integration
- Configure proper Terraform settings for Terramate-generated infrastructure

## Changes
- Added Terraform provider and backend configuration for Terramate

## Technical Details
This configures the Terraform providers and backend settings needed for Terramate to generate and manage infrastructure code properly.

## Test plan
- [ ] Verify Terramate generates correct provider configuration
- [ ] Test backend configuration works with state management
- [ ] Confirm provider versions are correct

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>