### PR TITLE
deploy lambda with zip

### DIFF
--- a/terraform/modules/regional/main.tf
+++ b/terraform/modules/regional/main.tf
@@ -55,6 +55,7 @@ module "lambda_stack" {
   project_name                      = var.project_name
   tenant_config_table_name          = module.core_infrastructure.tenant_config_table_name
   sqs_queue_arn                     = var.include_sqs_stack ? module.sqs_stack[0].log_delivery_queue_arn : ""
+  sqs_queue_url                     = var.include_sqs_stack ? module.sqs_stack[0].log_delivery_queue_url : ""
   ecr_image                         = var.ecr_image
   central_log_distribution_role_arn = var.central_log_distribution_role_arn
   lambda_execution_role_arn         = var.lambda_execution_role_arn

--- a/terraform/modules/regional/modules/lambda-stack/build_zip.sh
+++ b/terraform/modules/regional/modules/lambda-stack/build_zip.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+PACKAGE_DIR=build
+ZIP_NAME=log-processor.zip
+
+cd ../../../../../container
+
+rm $ZIP_NAME
+rm -r $PACKAGE_DIR
+pip3 install --target $PACKAGE_DIR -r requirements.txt
+cd $PACKAGE_DIR
+zip -r ../$ZIP_NAME .
+cd ../
+zip -g $ZIP_NAME log_processor.py
+
+mv $ZIP_NAME ../terraform/modules/regional/modules/lambda-stack

--- a/terraform/modules/regional/modules/lambda-stack/main.tf
+++ b/terraform/modules/regional/modules/lambda-stack/main.tf
@@ -34,18 +34,20 @@ resource "aws_cloudwatch_log_group" "log_distributor_log_group" {
 
 # Container-based Lambda function for log distribution
 resource "aws_lambda_function" "log_distributor_function" {
-  function_name = "${var.project_name}-${var.environment}-log-distributor"
-  package_type  = "Image"
-  image_uri     = "${data.aws_caller_identity.current.account_id}.dkr.ecr.${data.aws_region.current.name}.amazonaws.com/${var.ecr_image}"
-  role          = var.lambda_execution_role_arn
+  function_name    = "${var.project_name}-${var.environment}-log-distributor"
+  role             = var.lambda_execution_role_arn
+  filename         = "../../modules/regional/modules/lambda-stack/log-processor.zip"
+  handler          = "log_processor.lambda_handler"
+  runtime          = "python3.11"
+  source_code_hash = filebase64sha256("../../modules/regional/modules/lambda-stack/log-processor.zip")
 
   environment {
     variables = {
       TENANT_CONFIG_TABLE               = var.tenant_config_table_name
-      MAX_BATCH_SIZE                   = "1000"
-      RETRY_ATTEMPTS                   = "3"
+      MAX_BATCH_SIZE                    = "1000"
+      RETRY_ATTEMPTS                    = "3"
       CENTRAL_LOG_DISTRIBUTION_ROLE_ARN = var.central_log_distribution_role_arn
-      EXECUTION_MODE                   = "lambda"
+      SQS_QUEUE_URL                     = var.sqs_queue_url
     }
   }
 

--- a/terraform/modules/regional/modules/lambda-stack/variables.tf
+++ b/terraform/modules/regional/modules/lambda-stack/variables.tf
@@ -23,6 +23,10 @@ variable "sqs_queue_arn" {
   description = "ARN of the SQS queue to process messages from"
   type        = string
 }
+variable "sqs_queue_url" {
+  description = "URL of the SQS queue to re-queue messages"
+  type        = string
+}
 
 variable "ecr_image" {
   description = "ECR container image for the log processor"


### PR DESCRIPTION
ecr_replication only supports up to 25 regions account-wide, which isn’t enough for both stage and prod.