### PR TITLE
Add us-west-1 provider configuration

### DIFF
--- a/terraform/terramate/int/config.tf
+++ b/terraform/terramate/int/config.tf
@@ -58,3 +58,7 @@ provider "aws" {
   alias  = "us-west-2"
   region = "us-west-2"
 }
+provider "aws" {
+  alias  = "us-west-1"
+  region = "us-west-1"
+}


### PR DESCRIPTION
## Summary
- Add us-west-1 AWS provider configuration to Terraform
- Enable infrastructure deployment in us-west-1 region

## Changes
- Added us-west-1 AWS provider configuration

## Technical Details
This adds the AWS provider configuration for us-west-1 region to enable resource deployment in this region.

## Test plan
- [ ] Verify terraform plan includes us-west-1 provider
- [ ] Test resource deployment in us-west-1 region
- [ ] Confirm provider configuration works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>