### PR TITLE
Remove us-west-1 provider configuration

### DIFF
--- a/terraform/terramate/int/config.tf
+++ b/terraform/terramate/int/config.tf
@@ -58,7 +58,3 @@ provider "aws" {
   alias  = "us-west-2"
   region = "us-west-2"
 }
-provider "aws" {
-  alias  = "us-west-1"
-  region = "us-west-1"
-}


### PR DESCRIPTION
## Summary
- Remove us-west-1 AWS provider configuration from Terraform
- Clean up unused regional provider setup

## Changes
- Removed us-west-1 AWS provider configuration

## Technical Details
This removes the AWS provider configuration for us-west-1 region that is no longer needed in the infrastructure setup.

## Test plan
- [ ] Verify terraform plan works without us-west-1 provider
- [ ] Confirm no resources depend on us-west-1 provider
- [ ] Test deployment without removed provider

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>