### PR TITLE
Remove S3 bucket policy for cross-account access

### DIFF
--- a/terraform/modules/regional/main.tf
+++ b/terraform/modules/regional/main.tf
@@ -23,7 +23,6 @@ module "core_infrastructure" {
 
   environment                       = var.environment
   project_name                      = var.project_name
-  org_id                            = var.org_id
   s3_delete_after_days              = var.s3_delete_after_days
   enable_s3_encryption              = var.enable_s3_encryption
   central_log_distribution_role_arn = var.central_log_distribution_role_arn

--- a/terraform/modules/regional/modules/core-infrastructure/main.tf
+++ b/terraform/modules/regional/modules/core-infrastructure/main.tf
@@ -93,35 +93,6 @@ resource "aws_s3_bucket" "central_logging_bucket" {
     Name = "${var.project_name}-${var.environment}-central-logging"
   })
 }
-resource "aws_s3_bucket_policy" "allow_access_from_osdfm_org" {
-  bucket = aws_s3_bucket.central_logging_bucket.id
-
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        "Sid": "Allow Log Forwarder Writes",
-        "Effect": "Allow",
-        "Principal": {
-          "AWS": "*"
-        },
-        "Action": ["s3:GetBucketAcl", "s3:PutObject"],
-        "Resource": [
-          "arn:aws:s3:::${aws_s3_bucket.central_logging_bucket.id}",
-          "arn:aws:s3:::${aws_s3_bucket.central_logging_bucket.id}/*"
-        ],
-        "Condition": {
-          "ArnLike": {
-            "aws:PrincipalArn": "arn:aws:iam::*:role/hypershift-control-plane-log-forwarder"
-          },
-          "StringEquals": {
-            "aws:PrincipalOrgID": "${var.org_id}"
-          }
-        }
-      }
-    ]
-  })
-}
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "central_logging_bucket_encryption" {
   bucket = aws_s3_bucket.central_logging_bucket.id

--- a/terraform/modules/regional/modules/core-infrastructure/variables.tf
+++ b/terraform/modules/regional/modules/core-infrastructure/variables.tf
@@ -14,12 +14,6 @@ variable "project_name" {
   default     = "hcp-log"
 }
 
-variable "org_id" {
-  description = "ID of osdfm org"
-  type        = string
-  default     = ""
-}
-
 variable "s3_delete_after_days" {
   description = "Number of days after which to delete logs from S3"
   type        = number

--- a/terraform/modules/regional/variables.tf
+++ b/terraform/modules/regional/variables.tf
@@ -14,12 +14,6 @@ variable "project_name" {
   default     = "hcp-log"
 }
 
-variable "org_id" {
-  description = "ID of osdfm org"
-  type        = string
-  default     = ""
-}
-
 # Optional Stack Configuration
 variable "include_sqs_stack" {
   description = "Whether to deploy the SQS stack for log processing"

--- a/terraform/terramate/int/main.tf
+++ b/terraform/terramate/int/main.tf
@@ -13,7 +13,6 @@ module "regional-resource-ap-northeast-1" {
   }
   project_name                      = var.project_name
   environment                       = var.environment
-  org_id                            = var.org_id
   include_sqs_stack                 = var.include_sqs_stack
   include_lambda_stack              = var.include_lambda_stack
   ecr_image                         = var.ecr_image
@@ -29,7 +28,6 @@ module "regional-resource-ap-northeast-2" {
   }
   project_name                      = var.project_name
   environment                       = var.environment
-  org_id                            = var.org_id
   include_sqs_stack                 = var.include_sqs_stack
   include_lambda_stack              = var.include_lambda_stack
   ecr_image                         = var.ecr_image
@@ -45,7 +43,6 @@ module "regional-resource-ap-southeast-1" {
   }
   project_name                      = var.project_name
   environment                       = var.environment
-  org_id                            = var.org_id
   include_sqs_stack                 = var.include_sqs_stack
   include_lambda_stack              = var.include_lambda_stack
   ecr_image                         = var.ecr_image
@@ -61,7 +58,6 @@ module "regional-resource-eu-west-2" {
   }
   project_name                      = var.project_name
   environment                       = var.environment
-  org_id                            = var.org_id
   include_sqs_stack                 = var.include_sqs_stack
   include_lambda_stack              = var.include_lambda_stack
   ecr_image                         = var.ecr_image
@@ -77,7 +73,6 @@ module "regional-resource-eu-west-3" {
   }
   project_name                      = var.project_name
   environment                       = var.environment
-  org_id                            = var.org_id
   include_sqs_stack                 = var.include_sqs_stack
   include_lambda_stack              = var.include_lambda_stack
   ecr_image                         = var.ecr_image
@@ -93,7 +88,6 @@ module "regional-resource-us-east-1" {
   }
   project_name                      = var.project_name
   environment                       = var.environment
-  org_id                            = var.org_id
   include_sqs_stack                 = var.include_sqs_stack
   include_lambda_stack              = var.include_lambda_stack
   ecr_image                         = var.ecr_image
@@ -109,7 +103,6 @@ module "regional-resource-us-east-2" {
   }
   project_name                      = var.project_name
   environment                       = var.environment
-  org_id                            = var.org_id
   include_sqs_stack                 = var.include_sqs_stack
   include_lambda_stack              = var.include_lambda_stack
   ecr_image                         = var.ecr_image
@@ -125,7 +118,6 @@ module "regional-resource-us-west-2" {
   }
   project_name                      = var.project_name
   environment                       = var.environment
-  org_id                            = var.org_id
   include_sqs_stack                 = var.include_sqs_stack
   include_lambda_stack              = var.include_lambda_stack
   ecr_image                         = var.ecr_image

--- a/terraform/terramate/int/stack.tm.hcl
+++ b/terraform/terramate/int/stack.tm.hcl
@@ -39,7 +39,6 @@ generate_hcl "main.tf" {
         }
         project_name                      = var.project_name
         environment                       = var.environment
-        org_id                            = var.org_id
         include_sqs_stack                 = var.include_sqs_stack
         include_lambda_stack              = var.include_lambda_stack
         ecr_image                         = var.ecr_image


### PR DESCRIPTION
## Summary
- Remove S3 bucket policy that allowed cross-account access from OSDFM organization
- Simplify bucket permissions and rely on IAM roles for access control

## Changes
- **`terraform/modules/regional/modules/core-infrastructure/main.tf`**: Removed S3 bucket policy resource
- Removed org_id variable from regional and core infrastructure modules
- Updated Terramate stack configuration to remove org_id parameter

## Technical Details
### Removed Bucket Policy
The removed policy allowed:
- Cross-account access from OSDFM organization accounts
- Log forwarder role access from any account in the organization
- Conditional access based on PrincipalOrgID and PrincipalArn

### Security Impact
This change shifts from resource-based policies to:
- Pure IAM role-based access control
- Centralized permission management through global IAM roles
- More explicit cross-account access patterns

### Cleaned Variables
- Removed `org_id` parameter from all modules
- Updated Terramate stack generation to exclude org_id
- Simplified regional module variable requirements

## Test plan
- [ ] Verify terraform plan shows policy removal
- [ ] Test that IAM role-based access still works
- [ ] Confirm log forwarder can still write to buckets
- [ ] Validate cross-account access through IAM roles

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>