### PR TITLE
Fix S3 bucket ARN patterns in IAM policies

### DIFF
--- a/terraform/modules/global/main.tf
+++ b/terraform/modules/global/main.tf
@@ -74,8 +74,8 @@ resource "aws_iam_role_policy" "cross_account_assume_role_policy" {
           "s3:ListBucket"
         ]
         Resource = [
-          "arn:aws:s3:::${var.project_name}-*",
-          "arn:aws:s3:::${var.project_name}-*/*"
+          "arn:aws:s3:::${data.aws_caller_identity.current.account_id}-${var.project_name}-${var.environment}-*",
+          "arn:aws:s3:::${data.aws_caller_identity.current.account_id}-${var.project_name}-${var.environment}-*/*"
         ]
       },
       {
@@ -146,7 +146,7 @@ resource "aws_iam_role_policy" "central_s3_writer_policy" {
           "s3:PutObject",
           "s3:PutObjectAcl"
         ]
-        Resource = "arn:aws:s3:::${var.project_name}-*/*"
+        Resource = "arn:aws:s3:::${data.aws_caller_identity.current.account_id}-${var.project_name}-${var.environment}-*/*"
       },
       {
         Effect = "Allow"
@@ -154,7 +154,7 @@ resource "aws_iam_role_policy" "central_s3_writer_policy" {
           "s3:ListBucket",
           "s3:GetBucketLocation"
         ]
-        Resource = "arn:aws:s3:::${var.project_name}-*"
+        Resource = "arn:aws:s3:::${data.aws_caller_identity.current.account_id}-${var.project_name}-${var.environment}-*"
       },
       {
         Effect = "Allow"
@@ -234,8 +234,8 @@ resource "aws_iam_role_policy" "lambda_log_processor_policy" {
           "s3:ListBucket"
         ]
         Resource = [
-          "arn:aws:s3:::${var.project_name}-*",
-          "arn:aws:s3:::${var.project_name}-*/*"
+          "arn:aws:s3:::${data.aws_caller_identity.current.account_id}-${var.project_name}-${var.environment}-*",
+          "arn:aws:s3:::${data.aws_caller_identity.current.account_id}-${var.project_name}-${var.environment}-*/*"
         ]
       },
       # Assume the central log distribution role


### PR DESCRIPTION
## Summary
- Fix S3 bucket ARN patterns in IAM policies to use specific naming convention
- Update bucket references to include account ID and environment for security

## Changes
- **`terraform/modules/global/main.tf`**: Updated S3 bucket ARN patterns in IAM policies
  - **Cross-account assume role policy**: Updated bucket ARNs from `${var.project_name}-*` to `${account_id}-${var.project_name}-${var.environment}-*`
  - **Central S3 writer policy**: Updated bucket ARNs with specific naming pattern
  - **Lambda log processor policy**: Updated bucket ARNs for log processing access

## Technical Details
### Security Improvement
This change makes S3 bucket access more restrictive by using the specific bucket naming pattern:
`${account_id}-${project_name}-${environment}-*`

### Updated Policies
- Cross-account role bucket access
- Vector S3 writer permissions  
- Lambda log processor S3 access

This ensures IAM policies only grant access to buckets that follow the established naming convention.

## Test plan
- [ ] Verify terraform plan shows no resource changes
- [ ] Test cross-account role assumption still works
- [ ] Confirm Vector can write to S3 buckets
- [ ] Validate Lambda can access S3 for log processing

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>