### PR TITLE
Add CloudWatch permissions for Lambda function metrics

### DIFF
--- a/terraform/modules/global/main.tf
+++ b/terraform/modules/global/main.tf
@@ -252,6 +252,13 @@ resource "aws_iam_role_policy" "lambda_log_processor_policy" {
           "kms:DescribeKey"
         ]
         Resource = "*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "cloudwatch:PutMetricData"
+        ]
+        Resource = "*"
       }
     ]
   })


### PR DESCRIPTION
## Summary
- Add CloudWatch permissions to Lambda execution role for metric publishing
- Enable Lambda function to publish custom metrics to CloudWatch

## Changes
- **`terraform/modules/global/main.tf`**: Added CloudWatch PutMetricData permission to Lambda execution role

## Technical Details
This update grants the Lambda function the necessary permissions to publish custom metrics to CloudWatch, enabling monitoring and observability for log processing operations.

### Permission Added
```json
{
  "Effect": "Allow",
  "Action": [
    "cloudwatch:PutMetricData"
  ],
  "Resource": "*"
}
```

## Test plan
- [ ] Verify Lambda can publish metrics to CloudWatch
- [ ] Test custom metrics appear in CloudWatch console
- [ ] Confirm no permission errors in Lambda logs

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>