### PR TITLE
Fix checkout configuration to use main branch reference

### DIFF
--- a/.github/workflows/log-processor-zip-diff.yml
+++ b/.github/workflows/log-processor-zip-diff.yml
@@ -25,8 +25,9 @@ jobs:
         unzip -j terraform/modules/regional/modules/lambda-stack/log-processor.zip log_processor.py -d /tmp/current/
 
     - name: Checkout main branch
-      run: |
-        git checkout main
+      uses: actions/checkout@v4
+      with:
+        ref: "main"
         
     - name: Extract log_processor.py from main branch ZIP
       run: |


### PR DESCRIPTION
## Summary
- Fix GitHub Actions workflow checkout configuration to properly reference main branch
- Ensure workflows check out the correct branch for operations

## Changes
- Updated checkout configuration to use proper main branch reference

## Technical Details
This fix ensures GitHub Actions workflows check out the correct branch for consistent automation behavior.

## Test plan
- [ ] Verify workflows check out correct branch
- [ ] Confirm automation operations work as expected

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>