### PR TITLE
SREP-3416 - Ensure all returned errors are handled

### DIFF
--- a/container/cmd/log-processor/main.go
+++ b/container/cmd/log-processor/main.go
@@ -22,6 +22,15 @@ import (
 	"github.com/openshift/rosa-log-router/internal/processor"
 )
 
+// Exit codes
+const (
+	_ = iota // skip; 0 exit code indicates success
+	ExitCodeExecutionFailed
+	ExitCodeInvalidExecutionMode
+	ExitCodeLoadConfigFailed
+	ExitCodeLoadAWSConfigFailed
+)
+
 func main() {
 	// Parse command-line flags
 	mode := flag.String("mode", "", "Execution mode: sqs, manual, or scan (default: lambda)")
@@ -37,7 +46,11 @@ func main() {
 	logger.Info("log processor starting", "log_level", logLevel.String())
 
 	// Load configuration from environment
-	cfg := loadConfig()
+	cfg, err := loadConfig()
+	if err != nil {
+		logger.Error("failed to load configuration", "error", err)
+		os.Exit(ExitCodeLoadConfigFailed)
+	}
 
 	// Determine execution mode
 	executionMode := cfg.ExecutionMode
@@ -50,7 +63,7 @@ func main() {
 	awsCfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(cfg.AWSRegion))
 	if err != nil {
 		logger.Error("failed to load AWS config", "error", err)
-		os.Exit(1)
+		os.Exit(ExitCodeLoadAWSConfigFailed)
 	}
 
 	// Create AWS clients
@@ -79,7 +92,7 @@ func main() {
 		logger.Info("starting in SQS polling mode")
 		if err := sqsPollingMode(ctx, proc, sqsClient, cfg, logger); err != nil {
 			logger.Error("SQS polling mode failed", "error", err)
-			os.Exit(1)
+			os.Exit(ExitCodeExecutionFailed)
 		}
 
 	case "manual":
@@ -87,7 +100,7 @@ func main() {
 		logger.Info("starting in manual input mode")
 		if err := manualInputMode(ctx, proc, logger); err != nil {
 			logger.Error("manual input mode failed", "error", err)
-			os.Exit(1)
+			os.Exit(ExitCodeExecutionFailed)
 		}
 
 	case "scan":
@@ -95,31 +108,35 @@ func main() {
 		logger.Info("starting in scan mode")
 		if err := scanMode(ctx, proc, s3Client, cfg, logger); err != nil {
 			logger.Error("scan mode failed", "error", err)
-			os.Exit(1)
+			os.Exit(ExitCodeExecutionFailed)
 		}
 
 	default:
 		logger.Error("invalid execution mode", "mode", executionMode)
-		os.Exit(1)
+		os.Exit(ExitCodeInvalidExecutionMode)
 	}
 }
 
 // loadConfig loads configuration from environment variables
-func loadConfig() *models.Config {
+func loadConfig() (*models.Config, error) {
 	cfg := models.DefaultConfig()
 
 	if v := os.Getenv("TENANT_CONFIG_TABLE"); v != "" {
 		cfg.TenantConfigTable = v
 	}
 	if v := os.Getenv("MAX_BATCH_SIZE"); v != "" {
-		if i, err := strconv.Atoi(v); err == nil {
-			cfg.MaxBatchSize = i
+		i, err := strconv.Atoi(v)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert value of 'MAX_BATCH_SIZE' to integer: %w", err)
 		}
+		cfg.MaxBatchSize = i
 	}
 	if v := os.Getenv("RETRY_ATTEMPTS"); v != "" {
-		if i, err := strconv.Atoi(v); err == nil {
-			cfg.RetryAttempts = i
+		i, err := strconv.Atoi(v)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert value of 'RETRY_ATTEMPTS' to integer: %w", err)
 		}
+		cfg.RetryAttempts = i
 	}
 	if v := os.Getenv("CENTRAL_LOG_DISTRIBUTION_ROLE_ARN"); v != "" {
 		cfg.CentralLogDistributionRoleArn = v
@@ -137,9 +154,11 @@ func loadConfig() *models.Config {
 		cfg.SourceBucket = v
 	}
 	if v := os.Getenv("SCAN_INTERVAL"); v != "" {
-		if i, err := strconv.Atoi(v); err == nil {
-			cfg.ScanInterval = i
+		i, err := strconv.Atoi(v)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert value of 'SCAN_INTERVAL' to integer: %w", err)
 		}
+		cfg.ScanInterval = i
 	}
 	if v := os.Getenv("AWS_S3_USE_PATH_STYLE"); v != "" {
 		cfg.S3UsePathStyle = v == "true" || v == "1"
@@ -148,7 +167,7 @@ func loadConfig() *models.Config {
 		cfg.AWSEndpointURL = v
 	}
 
-	return cfg
+	return cfg, nil
 }
 
 // sqsPollingMode continuously polls SQS queue and processes messages

--- a/container/internal/models/types.go
+++ b/container/internal/models/types.go
@@ -44,8 +44,8 @@ func (c *DeliveryConfig) ApplicationEnabled(applicationName string) bool {
 
 // LogEvent represents a CloudWatch Logs event
 type LogEvent struct {
-	Timestamp interface{} `json:"timestamp"` // Can be int64, float64, or ISO string
-	Message   interface{} `json:"message"`   // Can be string or map[string]interface{}
+	Timestamp any `json:"timestamp"` // Can be int64, float64, or ISO string
+	Message   any `json:"message"`   // Can be string or map[string]interface{}
 }
 
 // ProcessingMetadata contains SQS message processing metadata

--- a/container/internal/processor/processor.go
+++ b/container/internal/processor/processor.go
@@ -125,6 +125,14 @@ func (p *Processor) ProcessSQSRecord(ctx context.Context, messageBody, messageID
 		return nil, models.NewInvalidS3NotificationError(fmt.Sprintf("invalid S3 event format: %v", err))
 	}
 
+	// Extract the processing metadata from message body
+	metadata, err := ExtractProcessingMetadata(messageBody)
+	if err != nil {
+		// Classify metadata extraction as a recoverable error: we wouldn't expect this to ever happen,
+		// so, if it fails on automatic retry, should end up in the dead-letter queue for examination
+		return deliveryStats, fmt.Errorf("failed to extract metadata from SQS message body: %w", err)
+	}
+
 	// Process each S3 record
 	for _, s3Record := range s3Event.Records {
 		bucketName := s3Record.S3.Bucket.Name
@@ -137,7 +145,7 @@ func (p *Processor) ProcessSQSRecord(ctx context.Context, messageBody, messageID
 			"bucket", bucketName,
 			"key", objectKey)
 
-		if err := p.processS3Object(ctx, bucketName, objectKey, messageBody, receiptHandle, deliveryStats); err != nil {
+		if err := p.processS3Object(ctx, bucketName, objectKey, messageBody, receiptHandle, metadata, deliveryStats); err != nil {
 			// Check if error is non-recoverable
 			if models.IsNonRecoverable(err) {
 				p.logger.Warn("non-recoverable error processing S3 object, continuing",
@@ -153,7 +161,7 @@ func (p *Processor) ProcessSQSRecord(ctx context.Context, messageBody, messageID
 }
 
 // processS3Object processes a single S3 object
-func (p *Processor) processS3Object(ctx context.Context, bucketName, objectKey, messageBody, receiptHandle string, deliveryStats *models.DeliveryStats) error {
+func (p *Processor) processS3Object(ctx context.Context, bucketName, objectKey, messageBody, receiptHandle string, metadata *models.ProcessingMetadata, deliveryStats *models.DeliveryStats) error {
 	// Extract tenant information from object key
 	tenantInfo, err := ExtractTenantInfoFromKey(objectKey, p.logger)
 	if err != nil {
@@ -185,7 +193,7 @@ func (p *Processor) processS3Object(ctx context.Context, bucketName, objectKey, 
 			"application", tenantInfo.Application)
 
 		// Deliver logs based on delivery type
-		if err := p.deliverLogs(ctx, bucketName, objectKey, deliveryType, deliveryConfig, tenantInfo, messageBody); err != nil {
+		if err := p.deliverLogs(ctx, bucketName, objectKey, deliveryType, deliveryConfig, tenantInfo, metadata); err != nil {
 			p.logger.Error("failed to deliver logs",
 				"tenant_id", tenantInfo.TenantID,
 				"delivery_type", deliveryType,
@@ -194,7 +202,6 @@ func (p *Processor) processS3Object(ctx context.Context, bucketName, objectKey, 
 
 			// For CloudWatch failures, try to re-queue with offset if possible
 			if deliveryType == "cloudwatch" && receiptHandle != "" && p.config.SQSQueueURL != "" {
-				metadata, _ := ExtractProcessingMetadata(messageBody)
 				if err := RequeueSQSMessageWithOffset(ctx, p.sqsClient, p.config.SQSQueueURL, messageBody, receiptHandle, metadata.Offset, 3, p.logger); err != nil {
 					p.logger.Error("failed to re-queue message", "error", err)
 				} else {
@@ -213,7 +220,7 @@ func (p *Processor) processS3Object(ctx context.Context, bucketName, objectKey, 
 }
 
 // deliverLogs handles log delivery based on type
-func (p *Processor) deliverLogs(ctx context.Context, bucketName, objectKey, deliveryType string, deliveryConfig *models.DeliveryConfig, tenantInfo *models.TenantInfo, messageBody string) error {
+func (p *Processor) deliverLogs(ctx context.Context, bucketName, objectKey, deliveryType string, deliveryConfig *models.DeliveryConfig, tenantInfo *models.TenantInfo, metadata *models.ProcessingMetadata) error {
 	s3Obj, uploadTime, err := GetS3Object(ctx, p.s3Client, bucketName, objectKey, p.logger)
 	if err != nil {
 		return fmt.Errorf("failed to retrieve object %q from S3 bucket %q: %w", objectKey, bucketName, err)
@@ -229,8 +236,6 @@ func (p *Processor) deliverLogs(ctx context.Context, bucketName, objectKey, deli
 			return err
 		}
 
-		// Check for processing offset and skip already processed events
-		metadata, _ := ExtractProcessingMetadata(messageBody)
 		if metadata.Offset > 0 {
 			p.logger.Info("found processing offset, skipping already processed events", "offset", metadata.Offset)
 			logEvents = ShouldSkipProcessedEvents(logEvents, metadata.Offset, p.logger)

--- a/container/internal/processor/sqs.go
+++ b/container/internal/processor/sqs.go
@@ -26,7 +26,7 @@ func ExtractProcessingMetadata(sqsRecordBody string) (*models.ProcessingMetadata
 	}
 
 	if err := json.Unmarshal([]byte(sqsRecordBody), &message); err != nil {
-		return &models.ProcessingMetadata{}, nil // Return empty metadata on parse error
+		return &models.ProcessingMetadata{}, fmt.Errorf("failed to extract metadata from SQS record: %w", err)
 	}
 
 	if message.ProcessingMetadata == nil {

--- a/container/internal/processor/sqs_test.go
+++ b/container/internal/processor/sqs_test.go
@@ -60,7 +60,7 @@ func TestExtractProcessingMetadata(t *testing.T) {
 
 		metadata, err := ExtractProcessingMetadata(messageBody)
 
-		require.NoError(t, err)
+		require.Error(t, err)
 		assert.Equal(t, 0, metadata.Offset)
 	})
 


### PR DESCRIPTION
https://issues.redhat.com/browse/SREP-3416

---

These changes introduce additional error handling around the configuration parsing and metadata extraction logic for the lambda container to ensure the HCP log-forwarding feature runs reliably.

Specifically:
* returns immediately if a config value is provided but cannot be parsed, to avoid obfuscating misconfigurations
* returns any errors related to unmarshalling metadata from the SQS record being processed
* parses SQS record metadata once, returning early if the record is corrupted/unreadable
* minor linting changes to `container/internal/models/types.go`


___

### **PR Type**
Bug fix

___

### **Description**
- Add error handling for configuration parsing to prevent silent failures
  - Return errors when environment variables fail integer conversion
  - Exit with code 99 on configuration load failure

- Improve SQS metadata extraction error handling
  - Return errors instead of silently ignoring parse failures
  - Extract metadata once at start of processing to catch corrupted records early

- Refactor metadata passing through delivery pipeline
  - Pass parsed metadata object instead of raw message body
  - Eliminate redundant metadata extraction calls

- Minor code quality improvements
  - Replace `interface{}` with `any` type alias in models
  - Remove unnecessary omitempty tag from JSON struct field


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["loadConfig function"] -->|now returns error| B["Error handling in main"]
  B -->|exits on failure| C["Exit code 99"]
  D["processS3Object"] -->|extract metadata early| E["ExtractProcessingMetadata"]
  E -->|return error on failure| F["Early return with error"]
  F -->|prevents silent failures| G["Reliable processing"]
  H["deliverLogs function"] -->|receive metadata object| I["Use parsed metadata"]
  I -->|eliminate redundant calls| J["Improved efficiency"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.go</strong><dd><code>Add error handling to configuration loading</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

container/cmd/log-processor/main.go

<ul><li>Modified <code>loadConfig()</code> to return error tuple and handle configuration <br>parsing failures<br> <li> Added error handling for integer conversion of <code>MAX_BATCH_SIZE</code>, <br><code>RETRY_ATTEMPTS</code>, and <code>SCAN_INTERVAL</code> environment variables<br> <li> Exit with code 99 when configuration loading fails<br> <li> Propagate parsing errors immediately instead of silently ignoring them</ul>


</details>


  </td>
  <td><a href="https://github.com/openshift-online/rosa-log-router/pull/265/files#diff-1ef353a60fd92b7255ce8d689c9264d1f1e5003a7de45ef2e6295570520b8839">+19/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>processor.go</strong><dd><code>Refactor metadata extraction and error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

container/internal/processor/processor.go

<ul><li>Extract SQS metadata once at the beginning of <code>processS3Object()</code> and <br>return error if parsing fails<br> <li> Pass parsed <code>ProcessingMetadata</code> object to <code>deliverLogs()</code> instead of raw <br>message body<br> <li> Remove redundant metadata extraction call in CloudWatch delivery path<br> <li> Eliminate error suppression in metadata extraction for re-queue <br>operation</ul>


</details>


  </td>
  <td><a href="https://github.com/openshift-online/rosa-log-router/pull/265/files#diff-8dce3eaac3a621b655b02c6ba0b28cb1c9f54ca3023ada8be39986f7a08a7331">+8/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sqs.go</strong><dd><code>Return errors from metadata extraction</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

container/internal/processor/sqs.go

<ul><li>Change <code>ExtractProcessingMetadata()</code> to return error instead of silently <br>returning empty metadata on parse failure<br> <li> Wrap JSON unmarshalling errors with descriptive error message</ul>


</details>


  </td>
  <td><a href="https://github.com/openshift-online/rosa-log-router/pull/265/files#diff-35389200e8755134160c7f65b1903e2f38dc144b0bcd61dd255465493c21b64c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>types.go</strong><dd><code>Update type annotations and struct tags</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

container/internal/models/types.go

<ul><li>Replace <code>interface{}</code> type with <code>any</code> type alias in <code>LogEvent</code> struct fields<br> <li> Remove <code>omitempty</code> tag from <code>RequeuedAt</code> field in <code>ProcessingMetadata</code> <br>struct</ul>


</details>


  </td>
  <td><a href="https://github.com/openshift-online/rosa-log-router/pull/265/files#diff-11b351e5ac5821e9a9ba9e8f0547cbf9ea6cb848f32fb833ea068d2de671e6fc">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

