### PR TITLE
Remove Cuppett from OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -5,7 +5,6 @@
 # via app-interface integration.
 
 maintainers:
-  - cuppett
   - jhjaggars
   - BumbleFeng
   - psav
@@ -14,7 +13,6 @@ maintainers:
   - Mhodesty
   - dustman9000
 approvers:
-  - cuppett
   - jhjaggars
   - BumbleFeng
   - psav


### PR DESCRIPTION
Removes `cuppett` from the OWNERS file, since users in this file are automatically added to the relevant handle on slack, which can be noisy.