### PR TITLE
SREP-4716 - Allow IAM path prefixes in customer log distribution role ARN

### DIFF
--- a/terraform/modules/global/README.md
+++ b/terraform/modules/global/README.md
@@ -63,7 +63,7 @@ module "global_iam" {
 ### Central Log Distribution Role
 
 #### Inline Policy Permissions
-- **Cross-account role assumption**: `sts:AssumeRole` on `arn:aws:iam::*:role/CustomerLogDistribution-*` with external ID validation
+- **Cross-account role assumption**: `sts:AssumeRole` on `arn:aws:iam::*:role/*CustomerLogDistribution-*` with external ID validation (supports IAM path prefixes)
 - **Source S3 access**: `s3:GetObject`, `s3:GetBucketLocation`, `s3:ListBucket` on `hcp-log-*` buckets
 - **Target S3 access**: `s3:PutObject` on all S3 buckets for cross-region delivery
 - **KMS operations**: `kms:Decrypt`, `kms:DescribeKey`, `kms:GenerateDataKey` on all KMS keys

--- a/terraform/modules/global/README.md
+++ b/terraform/modules/global/README.md
@@ -63,7 +63,7 @@ module "global_iam" {
 ### Central Log Distribution Role
 
 #### Inline Policy Permissions
-- **Cross-account role assumption**: `sts:AssumeRole` on `arn:aws:iam::*:role/*CustomerLogDistribution-*` with external ID validation (supports IAM path prefixes)
+- **Cross-account role assumption**: `sts:AssumeRole` on `arn:aws:iam::*:role/CustomerLogDistribution-*` and `arn:aws:iam::*:role/*/CustomerLogDistribution-*` with external ID validation (supports IAM path prefixes)
 - **Source S3 access**: `s3:GetObject`, `s3:GetBucketLocation`, `s3:ListBucket` on `hcp-log-*` buckets
 - **Target S3 access**: `s3:PutObject` on all S3 buckets for cross-region delivery
 - **KMS operations**: `kms:Decrypt`, `kms:DescribeKey`, `kms:GenerateDataKey` on all KMS keys

--- a/terraform/modules/global/main.tf
+++ b/terraform/modules/global/main.tf
@@ -59,7 +59,7 @@ resource "aws_iam_role_policy" "cross_account_assume_role_policy" {
         Action = [
           "sts:AssumeRole"
         ]
-        Resource = "arn:aws:iam::*:role/CustomerLogDistribution-*"
+        Resource = "arn:aws:iam::*:role/*CustomerLogDistribution-*"
         Condition = {
           StringEquals = {
             "sts:ExternalId" = data.aws_caller_identity.current.account_id

--- a/terraform/modules/global/main.tf
+++ b/terraform/modules/global/main.tf
@@ -59,7 +59,10 @@ resource "aws_iam_role_policy" "cross_account_assume_role_policy" {
         Action = [
           "sts:AssumeRole"
         ]
-        Resource = "arn:aws:iam::*:role/*CustomerLogDistribution-*"
+        Resource = [
+          "arn:aws:iam::*:role/CustomerLogDistribution-*",
+          "arn:aws:iam::*:role/*/CustomerLogDistribution-*"
+        ]
         Condition = {
           StringEquals = {
             "sts:ExternalId" = data.aws_caller_identity.current.account_id


### PR DESCRIPTION
**[SREP-4716](https://redhat.atlassian.net/browse/SREP-4716) - Allow IAM path prefixes in customer log distribution role ARN**


## Summary

- Broadens the `CrossAccountAssumeRolePolicy` resource pattern on `ROSA-CentralLogDistributionRole` from `arn:aws:iam::*:role/CustomerLogDistribution-*` to also include `arn:aws:iam::*:role/*/CustomerLogDistribution-*`, allowing customers to use IAM path prefixes in their role ARNs (e.g., `role/ros/CustomerLogDistribution-RH`)
- Updates the global module README to reflect the new pattern

## Problem

Customers who create their `CustomerLogDistribution-*` IAM role under an IAM path (e.g., `arn:aws:iam::<account>:role/ros/CustomerLogDistribution-RH`) are unable to forward control plane logs. The `ROSA-CentralLogDistributionRole` fails to assume the customer role because the current resource pattern `arn:aws:iam::*:role/CustomerLogDistribution-*` does not match ARNs with path segments between `role/` and `CustomerLogDistribution-`.

This results in an `AccessDenied` error at delivery time:
failed to assume customer role: operation error STS: AssumeRole, api error AccessDenied: User: ...assumed-role/ROSA-CentralLogDistributionRole-.../CentralLogDistribution-ID is not authorized to perform: sts:AssumeRole on resource: arn:aws:iam:::role/ros/CustomerLogDistribution-RH


## Fix
Changing the resource from `arn:aws:iam::*:role/CustomerLogDistribution-*`  to `arn:aws:iam::*:role/CustomerLogDistribution-*` or `arn:aws:iam::*:role/*/CustomerLogDistribution-*` matches:
- `role/CustomerLogDistribution-RH` (no path — existing behavior preserved)
- `role/ros/CustomerLogDistribution-RH` (single path segment)
The `sts:ExternalId` condition is unchanged, so the security posture is preserved.
## Test plan
- [ ] `terraform plan` on integration shows only the policy document change on `ROSA-CentralLogDistributionRole`
- [ ] Deploy to integration and verify log delivery works with a pathed role (e.g., `role/test/CustomerLogDistribution-test`)
- [ ] Verify log delivery still works with a non-pathed role (regression)
- [ ] Deploy to staging, repeat validation
- [ ] Deploy to production, confirm resolution with affected customer (MUFG Bank - [OHSS-52247](https://redhat.atlassian.net/browse/OHSS-52247))

## References
- Jira: https://redhat.atlassian.net/browse/SREP-4716
- Docs: https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/logging/rosa-forwarding-control-plane-logs