### PR TITLE
Disable API Gateway full data tracing

### DIFF
--- a/terraform/modules/regional/modules/api-stack/main.tf
+++ b/terraform/modules/regional/modules/api-stack/main.tf
@@ -723,7 +723,7 @@ resource "aws_api_gateway_method_settings" "all" {
   settings {
     metrics_enabled    = true
     logging_level      = "INFO"
-    data_trace_enabled = true
+    data_trace_enabled = false
   }
 
   depends_on = [aws_cloudwatch_log_group.api_gateway_log_welcome]


### PR DESCRIPTION
## Summary
- Disables `data_trace_enabled` on the API Gateway tenant management API method
  settings. Full request/response payload logging is not needed in production.
- Access logs (structured metadata: IP, status, latency, etc.) and execution flow
  logs remain enabled.

## Scope
- Single file change: `terraform/modules/regional/modules/api-stack/main.tf`
- Applies to the internal tenant management API Gateway across all regions and
  environments (int, stage, prod).
- No downstream consumers depend on the execution log payloads (no alarms,
  dashboards, or metric filters reference this log group).

## Note
For temporary debugging, developers can re-enable tracing per-environment via the
AWS CLI without a code change:
```bash
aws apigateway update-stage --region <region> \
  --rest-api-id <id> --stage-name <env> \
  --patch-operations op=replace,path=/~1*~1*/logging/dataTrace,value=true
```

## Test plan
- [ ] Verify `terraform plan` shows only the `data_trace_enabled` change
- [ ] Deploy to int and confirm API Gateway access logs still flow
- [ ] Send a test request and verify execution logs no longer contain request/response bodies
- [ ] Run `make test-e2e` against LocalStack

🤖 Generated with [Claude Code](https://claude.com/claude-code)