### PR TITLE
ROSAENG-61269, ROSAENG-61270: reduce log verbosity and tighten API Gateway settings

### DIFF
--- a/api/src/handlers/authorizer.py
+++ b/api/src/handlers/authorizer.py
@@ -67,8 +67,6 @@ def lambda_handler(event: Dict[str, Any], context) -> Dict[str, Any]:
         IAM policy response allowing or denying the request
     """
     try:
-        print(f"AUTHORIZER: Starting authorization for {event.get('methodArn', 'unknown')}")
-        
         # Extract request details from event
         method = event.get('httpMethod', '')
         path = event.get('path', '')
@@ -76,46 +74,31 @@ def lambda_handler(event: Dict[str, Any], context) -> Dict[str, Any]:
         body = event.get('body', '') or ''
 
         # Strip stage from path if present (LocalStack includes it, but AWS doesn't)
-        # Path format from LocalStack: /int/api/v1/... -> /api/v1/...
         request_context = event.get('requestContext', {})
         stage = request_context.get('stage', '')
         if stage and path.startswith(f'/{stage}/'):
-            path = path[len(stage) + 1:]  # Remove /{stage} prefix
-            print(f"AUTHORIZER: Stripped stage '{stage}' from path, new path={path}")
-        
+            path = path[len(stage) + 1:]
+
         # For proxy integrations, the actual HTTP method may be in the requestContext
         request_context = event.get('requestContext', {})
         actual_method = request_context.get('httpMethod', method)
-        
-        print(f"AUTHORIZER: Event method={method}, RequestContext method={actual_method}")
-        print(f"AUTHORIZER: Path={path}")
-        print(f"AUTHORIZER: Full event keys: {list(event.keys())}")
-        
+
         # Use the actual HTTP method from request context if available
         final_method = actual_method if actual_method != 'ANY' else method
-        
+
         # Check for auth headers (API Gateway lowercases headers)
         auth_header = headers.get('Authorization', '') or headers.get('authorization', '')
         timestamp_header = headers.get('X-API-Timestamp', '') or headers.get('x-api-timestamp', '')
-        
-        print(f"AUTHORIZER: Final method={final_method}")
-        print(f"AUTHORIZER: Auth header={auth_header}")
-        print(f"AUTHORIZER: Timestamp header={timestamp_header}")
-        
+
         # API Gateway may provide query string parameters separately
         query_string_parameters = event.get('queryStringParameters') or {}
-        
+
         # Construct full URI with query parameters
         uri = path
         if query_string_parameters:
             query_string = '&'.join([f"{k}={v}" for k, v in query_string_parameters.items()])
             uri = f"{path}?{query_string}"
-        
-        print(f"AUTHORIZER: Final URI={uri}")
-        print(f"AUTHORIZER: Body received: '{body}'")
-        print(f"AUTHORIZER: Body length: {len(body)}")
-        
-        # Now restore authentication with correct method
+
         try:
             is_authenticated = authenticate_request(
                 headers=headers,
@@ -125,12 +108,12 @@ def lambda_handler(event: Dict[str, Any], context) -> Dict[str, Any]:
                 psk_secret_name=PSK_SECRET_NAME,
                 region=AWS_REGION
             )
-            
+
             if is_authenticated:
-                print("AUTHORIZER: Authentication successful")
+                logger.info("Request authenticated")
                 return generate_policy(
-                    'authenticated-user', 
-                    'Allow', 
+                    'authenticated-user',
+                    'Allow',
                     event['methodArn'],
                     context={
                         'authenticated': 'true',
@@ -138,11 +121,11 @@ def lambda_handler(event: Dict[str, Any], context) -> Dict[str, Any]:
                     }
                 )
             else:
-                print("AUTHORIZER: Authentication failed")
+                logger.warning("Request authentication failed")
                 return generate_policy('unauthenticated', 'Deny', event['methodArn'])
-                
+
         except Exception as auth_error:
-            print(f"AUTHORIZER: Auth system error: {str(auth_error)}")
+            logger.error(f"Auth system error: {str(auth_error)}")
             return generate_policy('auth-error', 'Deny', event['methodArn'])
             
     except Exception as e:

--- a/api/src/handlers/authorizer.py
+++ b/api/src/handlers/authorizer.py
@@ -86,10 +86,6 @@ def lambda_handler(event: Dict[str, Any], context) -> Dict[str, Any]:
         # Use the actual HTTP method from request context if available
         final_method = actual_method if actual_method != 'ANY' else method
 
-        # Check for auth headers (API Gateway lowercases headers)
-        auth_header = headers.get('Authorization', '') or headers.get('authorization', '')
-        timestamp_header = headers.get('X-API-Timestamp', '') or headers.get('x-api-timestamp', '')
-
         # API Gateway may provide query string parameters separately
         query_string_parameters = event.get('queryStringParameters') or {}
 
@@ -124,8 +120,8 @@ def lambda_handler(event: Dict[str, Any], context) -> Dict[str, Any]:
                 logger.warning("Request authentication failed")
                 return generate_policy('unauthenticated', 'Deny', event['methodArn'])
 
-        except Exception as auth_error:
-            logger.error(f"Auth system error: {str(auth_error)}")
+        except Exception:
+            logger.exception("Auth system error")
             return generate_policy('auth-error', 'Deny', event['methodArn'])
             
     except Exception as e:

--- a/terraform/modules/regional/modules/api-stack/main.tf
+++ b/terraform/modules/regional/modules/api-stack/main.tf
@@ -723,7 +723,7 @@ resource "aws_api_gateway_method_settings" "all" {
   settings {
     metrics_enabled    = true
     logging_level      = "INFO"
-    data_trace_enabled = true
+    data_trace_enabled = false
   }
 
   depends_on = [aws_cloudwatch_log_group.api_gateway_log_welcome]


### PR DESCRIPTION
## Summary

- **api/src/handlers/authorizer.py**: remove debug `print()` statements that were emitting request metadata on every Lambda invocation; replace with structured `logger` calls that emit only auth outcomes (allowed/denied/error) with no header values or body content
- **terraform/modules/regional/modules/api-stack/main.tf**: set `data_trace_enabled = false` to stop API Gateway writing full request and response payloads to the execution log group

## Test plan

- [ ] Python unit tests pass
- [ ] Go build and vet clean
- [ ] Terraform validate clean
- [ ] Confirm CloudWatch execution logs no longer contain request/response bodies after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication request handling across HTTP methods, headers, paths, and query parameters.
  * Authentication failures and unexpected errors now return clearer access-denied responses.
  * Replaced verbose debug output with structured logging.

* **Security**
  * Disabled API Gateway request and response data tracing to reduce exposure of sensitive information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->