### PR TITLE
Add support for AWS govcloud parition

### DIFF
--- a/terraform/modules/global/main.tf
+++ b/terraform/modules/global/main.tf
@@ -26,6 +26,7 @@ locals {
 }
 
 data "aws_caller_identity" "current" {}
+data "aws_partition" "current" {}
 
 resource "aws_iam_role" "central_log_distribution_role" {
   name = "ROSA-CentralLogDistributionRole-${local.random_suffix}"
@@ -36,7 +37,7 @@ resource "aws_iam_role" "central_log_distribution_role" {
       {
         Effect = "Allow"
         Principal = {
-          AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+          AWS = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:root"
         }
         Action = "sts:AssumeRole"
       }
@@ -60,8 +61,8 @@ resource "aws_iam_role_policy" "cross_account_assume_role_policy" {
           "sts:AssumeRole"
         ]
         Resource = [
-          "arn:aws:iam::*:role/CustomerLogDistribution-*",
-          "arn:aws:iam::*:role/*/CustomerLogDistribution-*"
+          "arn:${data.aws_partition.current.partition}:iam::*:role/CustomerLogDistribution-*",
+          "arn:${data.aws_partition.current.partition}:iam::*:role/*/CustomerLogDistribution-*"
         ]
         Condition = {
           StringEquals = {
@@ -77,8 +78,8 @@ resource "aws_iam_role_policy" "cross_account_assume_role_policy" {
           "s3:ListBucket"
         ]
         Resource = [
-          "arn:aws:s3:::${data.aws_caller_identity.current.account_id}-${var.project_name}-${var.environment}-*",
-          "arn:aws:s3:::${data.aws_caller_identity.current.account_id}-${var.project_name}-${var.environment}-*/*"
+          "arn:${data.aws_partition.current.partition}:s3:::${data.aws_caller_identity.current.account_id}-${var.project_name}-${var.environment}-*",
+          "arn:${data.aws_partition.current.partition}:s3:::${data.aws_caller_identity.current.account_id}-${var.project_name}-${var.environment}-*/*"
         ]
       },
       {
@@ -87,8 +88,8 @@ resource "aws_iam_role_policy" "cross_account_assume_role_policy" {
           "s3:PutObject"
         ]
         Resource = [
-          "arn:aws:s3:::*",
-          "arn:aws:s3:::*/*"
+          "arn:${data.aws_partition.current.partition}:s3:::*",
+          "arn:${data.aws_partition.current.partition}:s3:::*/*"
         ]
         Condition = {
           StringNotEquals = {
@@ -130,7 +131,7 @@ resource "aws_iam_role" "central_s3_writer_role" {
             "aws:PrincipalOrgID" : "${var.org_id}"
           }
           ArnLike = {
-            "aws:PrincipalArn" : "arn:aws:iam::*:role/hypershift-control-plane-log-forwarder"
+            "aws:PrincipalArn" : "arn:${data.aws_partition.current.partition}:iam::*:role/hypershift-control-plane-log-forwarder"
           }
         }
         Action = "sts:AssumeRole"
@@ -154,7 +155,7 @@ resource "aws_iam_role_policy" "central_s3_writer_policy" {
           "s3:PutObject",
           "s3:PutObjectAcl"
         ]
-        Resource = "arn:aws:s3:::${data.aws_caller_identity.current.account_id}-${var.project_name}-${var.environment}-*/*"
+        Resource = "arn:${data.aws_partition.current.partition}:s3:::${data.aws_caller_identity.current.account_id}-${var.project_name}-${var.environment}-*/*"
       },
       {
         Effect = "Allow"
@@ -162,7 +163,7 @@ resource "aws_iam_role_policy" "central_s3_writer_policy" {
           "s3:ListBucket",
           "s3:GetBucketLocation"
         ]
-        Resource = "arn:aws:s3:::${data.aws_caller_identity.current.account_id}-${var.project_name}-${var.environment}-*"
+        Resource = "arn:${data.aws_partition.current.partition}:s3:::${data.aws_caller_identity.current.account_id}-${var.project_name}-${var.environment}-*"
       },
       {
         Effect = "Allow"
@@ -203,12 +204,12 @@ resource "aws_iam_role" "lambda_execution_role" {
 
 resource "aws_iam_role_policy_attachment" "lambda_execution_basic" {
   role       = aws_iam_role.lambda_execution_role.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
 }
 
 resource "aws_iam_role_policy_attachment" "lambda_execution_sqs" {
   role       = aws_iam_role.lambda_execution_role.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaSQSQueueExecutionRole"
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AWSLambdaSQSQueueExecutionRole"
 }
 
 resource "aws_iam_role_policy" "lambda_log_processor_policy" {
@@ -226,7 +227,7 @@ resource "aws_iam_role_policy" "lambda_log_processor_policy" {
           "dynamodb:Query",
           "dynamodb:BatchGetItem"
         ]
-        Resource = "arn:aws:dynamodb:*:${data.aws_caller_identity.current.account_id}:table/${var.project_name}-${var.environment}-tenant-configs"
+        Resource = "arn:${data.aws_partition.current.partition}:dynamodb:*:${data.aws_caller_identity.current.account_id}:table/${var.project_name}-${var.environment}-tenant-configs"
       },
       # S3 access for reading log files (all project buckets)
       {
@@ -237,8 +238,8 @@ resource "aws_iam_role_policy" "lambda_log_processor_policy" {
           "s3:ListBucket"
         ]
         Resource = [
-          "arn:aws:s3:::${data.aws_caller_identity.current.account_id}-${var.project_name}-${var.environment}-*",
-          "arn:aws:s3:::${data.aws_caller_identity.current.account_id}-${var.project_name}-${var.environment}-*/*"
+          "arn:${data.aws_partition.current.partition}:s3:::${data.aws_caller_identity.current.account_id}-${var.project_name}-${var.environment}-*",
+          "arn:${data.aws_partition.current.partition}:s3:::${data.aws_caller_identity.current.account_id}-${var.project_name}-${var.environment}-*/*"
         ]
       },
       # Assume the central log distribution role
@@ -261,7 +262,7 @@ resource "aws_iam_role_policy" "lambda_log_processor_policy" {
         Action = [
           "sqs:sendmessage"
         ]
-        Resource = "arn:aws:sqs:*:${data.aws_caller_identity.current.account_id}:${var.project_name}-${var.environment}-log-delivery-queue"
+        Resource = "arn:${data.aws_partition.current.partition}:sqs:*:${data.aws_caller_identity.current.account_id}:${var.project_name}-${var.environment}-log-delivery-queue"
       },
       {
         Effect = "Allow"
@@ -294,7 +295,7 @@ resource "aws_iam_role" "authorizer_execution_role" {
 
 resource "aws_iam_role_policy_attachment" "authorizer_execution_basic" {
   role       = aws_iam_role.authorizer_execution_role.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
 }
 
 # IAM Policy for Secrets Manager Access
@@ -310,7 +311,7 @@ resource "aws_iam_role_policy" "authorizer_sm_access" {
         Action = [
           "secretsmanager:GetSecretValue"
         ]
-        Resource = "arn:aws:secretsmanager:*:${data.aws_caller_identity.current.account_id}:secret:${var.project_name}-${var.environment}-psk*"
+        Resource = "arn:${data.aws_partition.current.partition}:secretsmanager:*:${data.aws_caller_identity.current.account_id}:secret:${var.project_name}-${var.environment}-psk*"
       }
     ]
   })
@@ -356,7 +357,7 @@ resource "aws_iam_role" "api_execution_role" {
 
 resource "aws_iam_role_policy_attachment" "api_execution_basic" {
   role       = aws_iam_role.api_execution_role.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
 }
 
 resource "aws_iam_role_policy" "api_dynamodb_access" {
@@ -377,7 +378,7 @@ resource "aws_iam_role_policy" "api_dynamodb_access" {
           "dynamodb:Query",
           "dynamodb:Scan"
         ]
-        Resource = "arn:aws:dynamodb:*:${data.aws_caller_identity.current.account_id}:table/${var.project_name}-${var.environment}-tenant-configs"
+        Resource = "arn:${data.aws_partition.current.partition}:dynamodb:*:${data.aws_caller_identity.current.account_id}:table/${var.project_name}-${var.environment}-tenant-configs"
       },
       {
         Effect = "Allow"
@@ -420,7 +421,7 @@ resource "aws_iam_role_policy" "invoke_authorizer_function" {
       {
         Effect   = "Allow"
         Action   = "lambda:InvokeFunction"
-        Resource = "arn:aws:lambda:*:${data.aws_caller_identity.current.account_id}:function:${var.project_name}-${var.environment}-api-authorizer:live"
+        Resource = "arn:${data.aws_partition.current.partition}:lambda:*:${data.aws_caller_identity.current.account_id}:function:${var.project_name}-${var.environment}-api-authorizer:live"
       }
     ]
   })
@@ -448,5 +449,5 @@ resource "aws_iam_role" "api_gateway_cloudwatch_role" {
 # Attach CloudWatch logging policy to API Gateway role
 resource "aws_iam_role_policy_attachment" "api_gateway_cloudwatch" {
   role       = aws_iam_role.api_gateway_cloudwatch_role.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs"
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs"
 }

--- a/terraform/modules/regional/modules/api-stack/main.tf
+++ b/terraform/modules/regional/modules/api-stack/main.tf
@@ -13,6 +13,7 @@ terraform {
 # Data sources for current AWS context
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
+data "aws_partition" "current" {}
 
 # Local values
 locals {
@@ -118,7 +119,7 @@ resource "aws_api_gateway_authorizer" "api_authorizer" {
   name                             = "${var.project_name}-${var.environment}-hmac-authorizer"
   rest_api_id                      = aws_api_gateway_rest_api.tenant_management_api.id
   type                             = "REQUEST"
-  authorizer_uri                   = "arn:aws:apigateway:${data.aws_region.current.id}:lambda:path/2015-03-31/functions/${aws_lambda_alias.authorizer_function_live.arn}/invocations"
+  authorizer_uri                   = "arn:${data.aws_partition.current.partition}:apigateway:${data.aws_region.current.id}:lambda:path/2015-03-31/functions/${aws_lambda_alias.authorizer_function_live.arn}/invocations"
   authorizer_credentials           = var.api_gateway_authorizer_role_arn
   authorizer_result_ttl_in_seconds = 0
   identity_source                  = "method.request.header.Authorization,method.request.header.X-API-Timestamp"
@@ -147,7 +148,7 @@ resource "aws_lambda_permission" "authorizer_invoke_permission" {
   qualifier     = aws_lambda_alias.authorizer_function_live.name
   action        = "lambda:InvokeFunction"
   principal     = "apigateway.amazonaws.com"
-  source_arn    = "arn:aws:execute-api:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:${aws_api_gateway_rest_api.tenant_management_api.id}/authorizers/${aws_api_gateway_authorizer.api_authorizer.id}"
+  source_arn    = "arn:${data.aws_partition.current.partition}:execute-api:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:${aws_api_gateway_rest_api.tenant_management_api.id}/authorizers/${aws_api_gateway_authorizer.api_authorizer.id}"
 }
 
 resource "aws_lambda_permission" "api_invoke_permission" {
@@ -155,7 +156,7 @@ resource "aws_lambda_permission" "api_invoke_permission" {
   qualifier     = aws_lambda_alias.api_function_live.name
   action        = "lambda:InvokeFunction"
   principal     = "apigateway.amazonaws.com"
-  source_arn    = "arn:aws:execute-api:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:${aws_api_gateway_rest_api.tenant_management_api.id}/*/*"
+  source_arn    = "arn:${data.aws_partition.current.partition}:execute-api:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:${aws_api_gateway_rest_api.tenant_management_api.id}/*/*"
 }
 
 # API Gateway Resources
@@ -239,7 +240,7 @@ resource "aws_api_gateway_integration" "health_integration" {
   http_method             = aws_api_gateway_method.health_method.http_method
   type                    = "AWS_PROXY"
   integration_http_method = "POST"
-  uri                     = "arn:aws:apigateway:${data.aws_region.current.id}:lambda:path/2015-03-31/functions/${aws_lambda_alias.api_function_live.arn}/invocations"
+  uri                     = "arn:${data.aws_partition.current.partition}:apigateway:${data.aws_region.current.id}:lambda:path/2015-03-31/functions/${aws_lambda_alias.api_function_live.arn}/invocations"
 }
 
 resource "aws_api_gateway_integration" "docs_integration" {
@@ -248,7 +249,7 @@ resource "aws_api_gateway_integration" "docs_integration" {
   http_method             = aws_api_gateway_method.docs_method.http_method
   type                    = "AWS_PROXY"
   integration_http_method = "POST"
-  uri                     = "arn:aws:apigateway:${data.aws_region.current.id}:lambda:path/2015-03-31/functions/${aws_lambda_alias.api_function_live.arn}/invocations"
+  uri                     = "arn:${data.aws_partition.current.partition}:apigateway:${data.aws_region.current.id}:lambda:path/2015-03-31/functions/${aws_lambda_alias.api_function_live.arn}/invocations"
 }
 
 resource "aws_api_gateway_integration" "redoc_integration" {
@@ -257,7 +258,7 @@ resource "aws_api_gateway_integration" "redoc_integration" {
   http_method             = aws_api_gateway_method.redoc_method.http_method
   type                    = "AWS_PROXY"
   integration_http_method = "POST"
-  uri                     = "arn:aws:apigateway:${data.aws_region.current.id}:lambda:path/2015-03-31/functions/${aws_lambda_alias.api_function_live.arn}/invocations"
+  uri                     = "arn:${data.aws_partition.current.partition}:apigateway:${data.aws_region.current.id}:lambda:path/2015-03-31/functions/${aws_lambda_alias.api_function_live.arn}/invocations"
 }
 
 resource "aws_api_gateway_integration" "openapi_integration" {
@@ -266,7 +267,7 @@ resource "aws_api_gateway_integration" "openapi_integration" {
   http_method             = aws_api_gateway_method.openapi_method.http_method
   type                    = "AWS_PROXY"
   integration_http_method = "POST"
-  uri                     = "arn:aws:apigateway:${data.aws_region.current.id}:lambda:path/2015-03-31/functions/${aws_lambda_alias.api_function_live.arn}/invocations"
+  uri                     = "arn:${data.aws_partition.current.partition}:apigateway:${data.aws_region.current.id}:lambda:path/2015-03-31/functions/${aws_lambda_alias.api_function_live.arn}/invocations"
 }
 
 resource "aws_api_gateway_method_response" "health_response" {
@@ -344,7 +345,7 @@ resource "aws_api_gateway_integration" "proxy_integration" {
   http_method             = aws_api_gateway_method.proxy_method.http_method
   type                    = "AWS_PROXY"
   integration_http_method = "POST"
-  uri                     = "arn:aws:apigateway:${data.aws_region.current.id}:lambda:path/2015-03-31/functions/${aws_lambda_alias.api_function_live.arn}/invocations"
+  uri                     = "arn:${data.aws_partition.current.partition}:apigateway:${data.aws_region.current.id}:lambda:path/2015-03-31/functions/${aws_lambda_alias.api_function_live.arn}/invocations"
 }
 
 resource "aws_api_gateway_method_response" "proxy_response" {

--- a/terraform/modules/regional/modules/core-infrastructure/main.tf
+++ b/terraform/modules/regional/modules/core-infrastructure/main.tf
@@ -12,6 +12,7 @@ terraform {
 # Data sources
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
+data "aws_partition" "current" {}
 
 # Local values
 locals {
@@ -36,7 +37,7 @@ resource "aws_kms_key" "logging_kms_key" {
         Sid    = "Enable IAM User Permissions"
         Effect = "Allow"
         Principal = {
-          AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+          AWS = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:root"
         }
         Action   = "kms:*"
         Resource = "*"

--- a/terraform/modules/regional/modules/core-infrastructure/variables.tf
+++ b/terraform/modules/regional/modules/core-infrastructure/variables.tf
@@ -34,7 +34,7 @@ variable "central_log_distribution_role_arn" {
   description = "ARN of the central log distribution role from global stack"
   type        = string
   validation {
-    condition     = can(regex("^arn:aws:iam::[0-9]{12}:role/ROSA-CentralLogDistributionRole-[a-f0-9]{8}$", var.central_log_distribution_role_arn))
+    condition     = can(regex("^arn:aws(-us-gov)?:iam::[0-9]{12}:role/ROSA-CentralLogDistributionRole-[a-f0-9]{8}$", var.central_log_distribution_role_arn))
     error_message = "Must be a valid IAM role ARN matching the expected pattern."
   }
 }

--- a/terraform/modules/regional/variables.tf
+++ b/terraform/modules/regional/variables.tf
@@ -40,7 +40,7 @@ variable "central_log_distribution_role_arn" {
   description = "ARN of the central log distribution role from global stack"
   type        = string
   validation {
-    condition     = can(regex("^arn:aws:iam::[0-9]{12}:role/ROSA-CentralLogDistributionRole-[a-f0-9]{8}$", var.central_log_distribution_role_arn))
+    condition     = can(regex("^arn:aws(-us-gov)?:iam::[0-9]{12}:role/ROSA-CentralLogDistributionRole-[a-f0-9]{8}$", var.central_log_distribution_role_arn))
     error_message = "Must be a valid IAM role ARN matching the expected pattern."
   }
 }
@@ -54,7 +54,7 @@ variable "lambda_execution_role_arn" {
   description = "ARN of the global Lambda execution role"
   type        = string
   validation {
-    condition     = can(regex("^arn:aws:iam::[0-9]{12}:role/.*lambda-execution-role$", var.lambda_execution_role_arn))
+    condition     = can(regex("^arn:aws(-us-gov)?:iam::[0-9]{12}:role/.*lambda-execution-role$", var.lambda_execution_role_arn))
     error_message = "Must be a valid IAM role ARN for Lambda execution."
   }
 }
@@ -68,7 +68,7 @@ variable "authorizer_execution_role_arn" {
   description = "ARN of the global Lambda authorizer execution role"
   type        = string
   validation {
-    condition     = can(regex("^arn:aws:iam::[0-9]{12}:role/.*api-authorizer-role$", var.authorizer_execution_role_arn))
+    condition     = can(regex("^arn:aws(-us-gov)?:iam::[0-9]{12}:role/.*api-authorizer-role$", var.authorizer_execution_role_arn))
     error_message = "Must be a valid IAM role ARN for Lambda execution."
   }
 }
@@ -82,7 +82,7 @@ variable "api_execution_role_arn" {
   description = "ARN of the global Lambda api execution role"
   type        = string
   validation {
-    condition     = can(regex("^arn:aws:iam::[0-9]{12}:role/.*api-service-role", var.api_execution_role_arn))
+    condition     = can(regex("^arn:aws(-us-gov)?:iam::[0-9]{12}:role/.*api-service-role", var.api_execution_role_arn))
     error_message = "Must be a valid IAM role ARN for Lambda execution."
   }
 }
@@ -96,7 +96,7 @@ variable "api_gateway_authorizer_role_arn" {
   description = "ARN of the global API Gateway authorizer execution role"
   type        = string
   validation {
-    condition     = can(regex("^arn:aws:iam::[0-9]{12}:role/.*api-gateway-authorizer-role", var.api_gateway_authorizer_role_arn))
+    condition     = can(regex("^arn:aws(-us-gov)?:iam::[0-9]{12}:role/.*api-gateway-authorizer-role", var.api_gateway_authorizer_role_arn))
     error_message = "Must be a valid IAM role ARN for API Gateway."
   }
 }
@@ -105,7 +105,7 @@ variable "api_gateway_cloudwatch_role_arn" {
   description = "ARN of the global API Gateway cloudwatch execution role"
   type        = string
   validation {
-    condition     = can(regex("^arn:aws:iam::[0-9]{12}:role/.*api-gateway-cloudwatch-role", var.api_gateway_cloudwatch_role_arn))
+    condition     = can(regex("^arn:aws(-us-gov)?:iam::[0-9]{12}:role/.*api-gateway-cloudwatch-role", var.api_gateway_cloudwatch_role_arn))
     error_message = "Must be a valid IAM role ARN for API Gateway."
   }
 }


### PR DESCRIPTION
### Summary
Utilize data source to determine AWS partition and replace references to `aws` with data source value. This enables deployment of defined resources into an AWS GovCloud account.

### Vallidations
This same refactor has been made against internal fork of repo. That MR includes link to validation test made against app-interface, targeting the refactored config.

### Ticket

https://redhat.atlassian.net/browse/ROSAENG-62922