### PR TITLE
Define FedRAMP ECR INT terraform config

### DIFF
--- a/terraform/terramate/ecr/fedramp/int/config.tf
+++ b/terraform/terramate/ecr/fedramp/int/config.tf
@@ -1,0 +1,56 @@
+// TERRAMATE: GENERATED AUTOMATICALLY DO NOT EDIT
+
+variable "access_key" {
+}
+variable "secret_key" {
+}
+variable "region" {
+}
+terraform {
+  required_version = ">= 1.8.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+  backend "s3" {
+  }
+}
+provider "aws" {
+  access_key = var.access_key
+  region     = var.region
+  secret_key = var.secret_key
+  default_tags {
+    tags = {
+      app-code               = "OSD-002"
+      cost-center            = "148"
+      managed_by_integration = "terraform-repo"
+      service-phase          = "dev"
+    }
+  }
+}
+provider "aws" {
+  alias  = "us-gov-east-1"
+  region = "us-gov-east-1"
+  default_tags {
+    tags = {
+      app-code               = "OSD-002"
+      cost-center            = "148"
+      managed_by_integration = "terraform-repo"
+      service-phase          = "dev"
+    }
+  }
+}
+provider "aws" {
+  alias  = "us-gov-west-1"
+  region = "us-gov-west-1"
+  default_tags {
+    tags = {
+      app-code               = "OSD-002"
+      cost-center            = "148"
+      managed_by_integration = "terraform-repo"
+      service-phase          = "dev"
+    }
+  }
+}

--- a/terraform/terramate/ecr/fedramp/int/main.tf
+++ b/terraform/terramate/ecr/fedramp/int/main.tf
@@ -1,0 +1,41 @@
+// TERRAMATE: GENERATED AUTOMATICALLY DO NOT EDIT
+
+data "aws_caller_identity" "current" {
+}
+resource "aws_ecr_replication_configuration" "ecr_replication" {
+  replication_configuration {
+    rule {
+      dynamic "destination" {
+        for_each = [for r in ["us-gov-east-1", "us-gov-west-1"] : r if r != var.region]
+        content {
+          region      = destination.value
+          registry_id = data.aws_caller_identity.current.account_id
+        }
+      }
+    }
+  }
+}
+resource "aws_ecr_repository" "rosa-log-router-api-us-gov-east-1" {
+  name     = "rosa-log-router-api"
+  provider = aws.us-gov-east-1
+}
+resource "aws_ecr_repository" "rosa-log-router-api-us-gov-west-1" {
+  name     = "rosa-log-router-api"
+  provider = aws.us-gov-west-1
+}
+resource "aws_ecr_repository" "rosa-log-router-authorizer-us-gov-east-1" {
+  name     = "rosa-log-router-authorizer"
+  provider = aws.us-gov-east-1
+}
+resource "aws_ecr_repository" "rosa-log-router-authorizer-us-gov-west-1" {
+  name     = "rosa-log-router-authorizer"
+  provider = aws.us-gov-west-1
+}
+resource "aws_ecr_repository" "rosa-log-router-processor-go-us-gov-east-1" {
+  name     = "rosa-log-router-processor-go"
+  provider = aws.us-gov-east-1
+}
+resource "aws_ecr_repository" "rosa-log-router-processor-go-us-gov-west-1" {
+  name     = "rosa-log-router-processor-go"
+  provider = aws.us-gov-west-1
+}

--- a/terraform/terramate/ecr/fedramp/int/stack.tm.hcl
+++ b/terraform/terramate/ecr/fedramp/int/stack.tm.hcl
@@ -1,0 +1,114 @@
+stack {
+  name        = "fedramp-int-environment"
+  description = "FedRAMP integration environment ecr resources (GovCloud partition)"
+}
+
+globals "aws" {
+  # FedRAMP / GovCloud only supports the two GovCloud regions.
+  regions = [
+    "us-gov-east-1",
+    "us-gov-west-1"
+  ]
+  # Regions to remove. Terraform still requires provider configuration for deletion operations.
+  delete_regions = []
+  default_tags = {
+    "app-code"               = "OSD-002"
+    "cost-center"            = "148"
+    "service-phase"          = "dev"
+    "managed_by_integration" = "terraform-repo"
+  }
+}
+
+generate_hcl "main.tf" {
+
+  content {
+
+    data "aws_caller_identity" "current" {}
+
+    resource "aws_ecr_replication_configuration" "ecr_replication" {
+      replication_configuration {
+        rule {
+          dynamic "destination" {
+            for_each = [for r in global.aws.regions : r if r != var.region]
+            content {
+              region      = destination.value
+              registry_id = data.aws_caller_identity.current.account_id
+            }
+          }
+        }
+      }
+    }
+
+    tm_dynamic "resource" {
+      for_each = global.aws.regions
+      iterator = region
+      labels   = ["aws_ecr_repository", "rosa-log-router-api-${region.value}"]
+      attributes = {
+        provider = tm_hcl_expression("aws.${region.value}")
+        name     = "rosa-log-router-api"
+      }
+    }
+
+    tm_dynamic "resource" {
+      for_each = global.aws.regions
+      iterator = region
+      labels   = ["aws_ecr_repository", "rosa-log-router-authorizer-${region.value}"]
+      attributes = {
+        provider = tm_hcl_expression("aws.${region.value}")
+        name     = "rosa-log-router-authorizer"
+      }
+    }
+
+    tm_dynamic "resource" {
+      for_each = global.aws.regions
+      iterator = region
+      labels   = ["aws_ecr_repository", "rosa-log-router-processor-go-${region.value}"]
+      attributes = {
+        provider = tm_hcl_expression("aws.${region.value}")
+        name     = "rosa-log-router-processor-go"
+      }
+    }
+  }
+}
+
+generate_hcl "config.tf" {
+  content {
+
+    variable "access_key" {}
+    variable "secret_key" {}
+    variable "region" {}
+
+    terraform {
+      required_version = ">= 1.8.5"
+      required_providers {
+        aws = {
+          source  = "hashicorp/aws"
+          version = "~> 6.0"
+        }
+      }
+      backend "s3" {}
+    }
+
+    provider "aws" {
+      access_key = var.access_key
+      secret_key = var.secret_key
+      region     = var.region
+      default_tags {
+        tags = global.aws.default_tags
+      }
+    }
+
+    tm_dynamic "provider" {
+      for_each = tm_concat(global.aws.regions, global.aws.delete_regions)
+      iterator = region
+      labels   = ["aws"]
+      content {
+        alias  = region.value
+        region = region.value
+        default_tags {
+          tags = global.aws.default_tags
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
[ROSAENG-61395](https://redhat.atlassian.net/browse/ROSAENG-61395)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added FedRAMP-compatible container image repositories across both AWS GovCloud regions.
  * Enabled cross-region replication for supported images while excluding the active region.
  * Added regional support for log router, authorizer, and Go processor images.
  * Configured consistent tagging and deployment settings for the GovCloud environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->