### PR TITLE
ROSAENG-61317: Remove wildcard allowedUnsafeSysctls from Vector SCC

### DIFF
--- a/k8s/collector/openshift-base/scc.yaml
+++ b/k8s/collector/openshift-base/scc.yaml
@@ -18,8 +18,6 @@ requiredDropCapabilities:
 - MKNOD
 runAsUser:
   type: RunAsAny
-allowedUnsafeSysctls:
-- '*'
 seLinuxContext:
   type: RunAsAny
 supplementalGroups:


### PR DESCRIPTION
## Summary
- Removes the `allowedUnsafeSysctls: ["*"]` entry from the Vector CI test SCC (`k8s/collector/openshift-base/scc.yaml`)
- Vector does not use custom sysctls, so the wildcard entry is unnecessary
- Resolves [ROSAENG-61317](https://redhat.atlassian.net/browse/ROSAENG-61317)

## Test plan
- [ ] Both CI integration test workflows pass (localstack + minikube)
- [ ] Vector pods start successfully in CI without the sysctl allowance

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed unrestricted unsafe sysctl permissions from the OpenShift security configuration, strengthening workload security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->